### PR TITLE
cleanup related to metaclass property

### DIFF
--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -234,13 +234,13 @@ class MultiWorld():
             self.custom_data[player] = {}
             world_type = AutoWorld.AutoWorldRegister.world_types[self.game[player]]
             self.worlds[player] = world_type(self, player)
-            for option_key in typing.get_type_hints(world_type.options_dataclass):
+            for option_key in world_type.options_dataclass.type_hints:
                 option_values = getattr(args, option_key, {})
                 setattr(self, option_key, option_values)
                 # TODO - remove this loop once all worlds use options dataclasses
             options_dataclass: typing.Type[Options.GameOptions] = self.worlds[player].options_dataclass
             self.worlds[player].o = options_dataclass(**{option_key: getattr(args, option_key)[player]
-                                                         for option_key in typing.get_type_hints(options_dataclass)})
+                                                         for option_key in options_dataclass.type_hints})
 
     def set_item_links(self):
         item_links = {}

--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
-import collections
 import copy
-import itertools
 import functools
 import json
 import logging
@@ -201,10 +199,6 @@ class MultiWorld():
         self._region_cache[new_id] = {}
         world_type = AutoWorld.AutoWorldRegister.world_types[game]
         for option_key, option in world_type.options_dataclass.type_hints.items():
-            getattr(self, option_key)[new_id] = option(option.default)
-        for option_key, option in Options.common_options.items():
-            getattr(self, option_key)[new_id] = option(option.default)
-        for option_key, option in Options.per_game_common_options.items():
             getattr(self, option_key)[new_id] = option(option.default)
 
         self.worlds[new_id] = world_type(self, new_id)

--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -1586,7 +1586,7 @@ class Spoiler():
                     outfile.write('\nPlayer %d: %s\n' % (player, self.multiworld.get_player_name(player)))
                 outfile.write('Game:                            %s\n' % self.multiworld.game[player])
 
-                for f_option, option in self.multiworld.worlds[player].o.__annotations__.items():
+                for f_option, option in self.multiworld.worlds[player].options_dataclass.type_hints.items():
                     write_option(f_option, option)
 
                 AutoWorld.call_single(self.multiworld, "write_spoiler_header", player, outfile)

--- a/Generate.py
+++ b/Generate.py
@@ -156,7 +156,8 @@ def main(args=None, callback=ERmain):
                         for yaml in weights_cache[path]:
                             if category_name is None:
                                 for category in yaml:
-                                    if category in AutoWorldRegister.world_types and key in Options.common_options:
+                                    if category in AutoWorldRegister.world_types and \
+                                            key in Options.CommonOptions.type_hints:
                                         yaml[category][key] = option
                             elif category_name not in yaml:
                                 logging.warning(f"Meta: Category {category_name} is not present in {path}.")
@@ -444,8 +445,8 @@ def roll_settings(weights: dict, plando_options: PlandoOptions = PlandoOptions.b
                                 f"which is not enabled.")
 
     ret = argparse.Namespace()
-    for option_key in Options.per_game_common_options:
-        if option_key in weights and option_key not in Options.common_options:
+    for option_key in Options.PerGameCommonOptions.type_hints:
+        if option_key in weights and option_key not in Options.CommonOptions.type_hints:
             raise Exception(f"Option {option_key} has to be in a game's section, not on its own.")
 
     ret.game = get_choice("game", weights)
@@ -460,7 +461,7 @@ def roll_settings(weights: dict, plando_options: PlandoOptions = PlandoOptions.b
         game_weights = weights[ret.game]
 
     ret.name = get_choice('name', weights)
-    for option_key, option in Options.common_options.items():
+    for option_key, option in Options.CommonOptions.type_hints.items():
         setattr(ret, option_key, option.from_any(get_choice(option_key, weights, option.default)))
 
     if ret.game in AutoWorldRegister.world_types:

--- a/Options.py
+++ b/Options.py
@@ -887,10 +887,6 @@ class CommonOptions(metaclass=OptionsMetaProperty):
         return option_results
 
 
-common_options = typing.get_type_hints(CommonOptions)
-# TODO - remove this dict once all worlds use options dataclasses
-
-
 class ItemSet(OptionSet):
     verify_item_name = True
     convert_name_groups = True
@@ -1014,10 +1010,6 @@ class PerGameCommonOptions(CommonOptions):
     exclude_locations: ExcludeLocations
     priority_locations: PriorityLocations
     item_links: ItemLinks
-
-
-per_game_common_options = typing.get_type_hints(PerGameCommonOptions)
-# TODO - remove this dict once all worlds use options dataclasses
 
 
 GameOptions = typing.TypeVar("GameOptions", bound=PerGameCommonOptions)

--- a/Options.py
+++ b/Options.py
@@ -873,17 +873,17 @@ class CommonOptions(metaclass=OptionsMetaProperty):
     progression_balancing: ProgressionBalancing
     accessibility: Accessibility
 
-    def as_dict(self, *args: str) -> typing.Dict[str, typing.Any]:
+    def as_dict(self, *option_names: str) -> typing.Dict[str, typing.Any]:
         """
         Pass the option_names you would like returned as a dictionary as strings.
         Returns a dictionary of [str, Option.value]
         """
         option_results = {}
-        for option_name in args:
-            if option_name in self.__annotations__:
+        for option_name in option_names:
+            if option_name in type(self).type_hints:
                 option_results[option_name] = getattr(self, option_name).value
             else:
-                raise ValueError(f"{option_name} not found in {self.__annotations__}")
+                raise ValueError(f"{option_name} not found in {tuple(type(self).type_hints)}")
         return option_results
 
 

--- a/Options.py
+++ b/Options.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 import abc
 from copy import deepcopy
 from dataclasses import dataclass
+import functools
 import math
 import numbers
 import typing
@@ -863,6 +864,7 @@ class ProgressionBalancing(SpecialRange):
 
 class OptionsMetaProperty(type):
     @property
+    @functools.lru_cache(maxsize=None)
     def type_hints(cls) -> typing.Dict[str, AssembleOptions]:
         """Returns type hints of the class as a dictionary."""
         return typing.get_type_hints(cls)

--- a/Utils.py
+++ b/Utils.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-import types
 import typing
 import builtins
 import os

--- a/docs/world api.md
+++ b/docs/world api.md
@@ -329,6 +329,7 @@ class FixXYZGlitch(Toggle):
     display_name = "Fix XYZ Glitch"
 
 # By convention, we call the options dataclass `<world>Options`.
+# It has to be derived from 'PerGameCommonOptions'.
 @dataclass
 class MyGameOptions(PerGameCommonOptions):
     difficulty: Difficulty

--- a/test/general/TestFill.py
+++ b/test/general/TestFill.py
@@ -1,6 +1,4 @@
-import itertools
-from argparse import Namespace
-from typing import get_type_hints, List, Iterable
+from typing import List, Iterable
 import unittest
 
 import Options
@@ -25,14 +23,14 @@ def generate_multi_world(players: int = 1) -> MultiWorld:
         multi_world.player_name[player_id] = "Test Player " + str(player_id)
         region = Region("Menu", player_id, multi_world, "Menu Region Hint")
         multi_world.regions.append(region)
-        for option_key, option in get_type_hints(Options.PerGameCommonOptions).items():
+        for option_key, option in Options.PerGameCommonOptions.type_hints.items():
             if hasattr(multi_world, option_key):
                 getattr(multi_world, option_key).setdefault(player_id, option.from_any(getattr(option, "default")))
             else:
                 setattr(multi_world, option_key, {player_id: option.from_any(getattr(option, "default"))})
         # TODO - remove this loop once all worlds use options dataclasses
         world.o = world.options_dataclass(**{option_key: getattr(multi_world, option_key)[player_id]
-                                             for option_key in get_type_hints(world.options_dataclass)})
+                                             for option_key in world.options_dataclass.type_hints})
 
     multi_world.set_seed(0)
 

--- a/test/general/__init__.py
+++ b/test/general/__init__.py
@@ -1,20 +1,20 @@
 from argparse import Namespace
-from typing import get_type_hints
+from typing import Type
 
 from BaseClasses import MultiWorld, CollectionState
-from worlds.AutoWorld import call_all
+from worlds.AutoWorld import call_all, World
 
 gen_steps = ["generate_early", "create_regions", "create_items", "set_rules", "generate_basic", "pre_fill"]
 
 
-def setup_solo_multiworld(world_type) -> MultiWorld:
+def setup_solo_multiworld(world_type: Type[World]) -> MultiWorld:
     multiworld = MultiWorld(1)
     multiworld.game[1] = world_type.game
     multiworld.player_name = {1: "Tester"}
     multiworld.set_seed()
     multiworld.state = CollectionState(multiworld)
     args = Namespace()
-    for name, option in get_type_hints(world_type.options_dataclass).items():
+    for name, option in world_type.options_dataclass.type_hints.items():
         setattr(args, name, {1: option.from_any(option.default)})
     multiworld.set_options(args)
     for step in gen_steps:

--- a/worlds/AutoWorld.py
+++ b/worlds/AutoWorld.py
@@ -7,7 +7,7 @@ from dataclasses import make_dataclass
 from typing import Dict, FrozenSet, Set, Tuple, List, Optional, TextIO, Any, Callable, Type, Union, TYPE_CHECKING, \
     ClassVar
 
-from Options import AssembleOptions, GameOptions, PerGameCommonOptions
+from Options import GameOptions, PerGameCommonOptions
 from BaseClasses import CollectionState
 
 if TYPE_CHECKING:
@@ -138,7 +138,6 @@ class World(metaclass=AutoWorldRegister):
     """A World object encompasses a game's Items, Locations, Rules and additional data or functionality required.
     A Game should have its own subclass of World in which it defines the required data structures."""
 
-    option_definitions: ClassVar[Dict[str, AssembleOptions]] = {}  # TODO - remove this once all worlds use options dataclasses
     options_dataclass: Type[GameOptions] = PerGameCommonOptions  # link your Options mapping
     o: PerGameCommonOptions
 

--- a/worlds/ror2/__init__.py
+++ b/worlds/ror2/__init__.py
@@ -1,5 +1,4 @@
 import string
-from typing import get_type_hints
 
 from .Items import RiskOfRainItem, item_table, item_pool_weights, environment_offest
 from .Locations import RiskOfRainLocation, get_classic_item_pickups, item_pickups, orderedstage_location


### PR DESCRIPTION
- move remaining usages from get_type_hints to metaclass property
- move remaining usages from \_\_annotations\_\_ to metaclass property
- move remaining usages from legacy dictionaries to metaclass property
- remove legacy dictionaries
- cache the metaclass property

- clarify inheritance in world api