### PR TITLE
remove TypeVar that isn't used

### DIFF
--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -237,7 +237,7 @@ class MultiWorld():
                 option_values = getattr(args, option_key, {})
                 setattr(self, option_key, option_values)
                 # TODO - remove this loop once all worlds use options dataclasses
-            options_dataclass: typing.Type[Options.GameOptions] = self.worlds[player].options_dataclass
+            options_dataclass: typing.Type[Options.PerGameCommonOptions] = self.worlds[player].options_dataclass
             self.worlds[player].options = options_dataclass(**{option_key: getattr(args, option_key)[player]
                                                                for option_key in options_dataclass.type_hints})
 

--- a/Options.py
+++ b/Options.py
@@ -899,7 +899,7 @@ class ProgressionBalancing(SpecialRange):
     }
 
 
-class OptionsMetaProperty(abc.ABCMeta):
+class OptionsMetaProperty(type):
     def __new__(mcs,
                 name: str,
                 bases: typing.Tuple[type, ...],

--- a/Options.py
+++ b/Options.py
@@ -899,16 +899,19 @@ class ProgressionBalancing(SpecialRange):
     }
 
 
-class OptionsMetaProperty(type):
-    def __new__(mcs, name, bases, attrs):
-        for attr, attr_type in attrs.items():
+class OptionsMetaProperty(abc.ABCMeta):
+    def __new__(mcs,
+                name: str,
+                bases: typing.Tuple[type, ...],
+                attrs: typing.Dict[str, typing.Any]) -> "OptionsMetaProperty":
+        for attr_type in attrs.values():
             assert not isinstance(attr_type, AssembleOptions),\
                 f"Options for {name} should be type hinted on the class, not assigned"
         return super().__new__(mcs, name, bases, attrs)
 
     @property
     @functools.lru_cache(maxsize=None)
-    def type_hints(cls) -> typing.Dict[str, AssembleOptions]:
+    def type_hints(cls) -> typing.Dict[str, typing.Type[Option[typing.Any]]]:
         """Returns type hints of the class as a dictionary."""
         return typing.get_type_hints(cls)
 
@@ -1075,10 +1078,6 @@ class PerGameCommonOptions(CommonOptions):
     exclude_locations: ExcludeLocations
     priority_locations: PriorityLocations
     item_links: ItemLinks
-
-
-GameOptions = typing.TypeVar("GameOptions", bound=PerGameCommonOptions)
-
 
 
 def generate_yaml_templates(target_folder: typing.Union[str, "pathlib.Path"], generate_hidden: bool = True):

--- a/worlds/AutoWorld.py
+++ b/worlds/AutoWorld.py
@@ -8,7 +8,7 @@ from dataclasses import make_dataclass
 from typing import Any, Callable, ClassVar, Dict, Set, Tuple, FrozenSet, List, Optional, TYPE_CHECKING, TextIO, Type, \
     Union
 
-from Options import GameOptions, PerGameCommonOptions
+from Options import PerGameCommonOptions
 from BaseClasses import CollectionState
 
 if TYPE_CHECKING:
@@ -170,7 +170,7 @@ class World(metaclass=AutoWorldRegister):
     """A World object encompasses a game's Items, Locations, Rules and additional data or functionality required.
     A Game should have its own subclass of World in which it defines the required data structures."""
 
-    options_dataclass: Type[GameOptions] = PerGameCommonOptions
+    options_dataclass: ClassVar[Type[PerGameCommonOptions]] = PerGameCommonOptions
     """link your Options mapping"""
     options: PerGameCommonOptions
     """resulting options for the player of this world"""


### PR DESCRIPTION
My understanding of `TypeVar` is that it's only for use as the parameter of a `Generic`.
And where you have used it, my type checker says `Type variable "GameOptions" has no meaning in this context`